### PR TITLE
Immersive mode on player compatible with others APIs Level

### DIFF
--- a/src/android/Player.java
+++ b/src/android/Player.java
@@ -180,7 +180,12 @@ public class Player {
         dialog.getWindow().getAttributes().windowAnimations = android.R.style.Animation_Dialog;
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
         View decorView = dialog.getWindow().getDecorView();
-        int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN;
+        int uiOptions = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
         decorView.setSystemUiVisibility(uiOptions);
         dialog.setCancelable(true);
         dialog.setOnDismissListener(dismissListener);


### PR DESCRIPTION
I tested its fix but only hides the virtual buttons when the video starts, but when I tap the screen to appear the controls the buttons do not disappear anymore. I made some modifications and now it worked perfectly.
Look at my fork