### PR TITLE
Creates autoplay functionality through params

### DIFF
--- a/src/android/Configuration.java
+++ b/src/android/Configuration.java
@@ -56,6 +56,10 @@ public class Configuration {
         return config.optBoolean("audioOnly");
     }
 
+    public boolean autoPlay() {
+        return config.optBoolean("autoPlay", true);
+    }
+
     public long getSeekTo() {
         return config.optLong("seekTo", -1);
     }

--- a/src/android/Player.java
+++ b/src/android/Player.java
@@ -250,7 +250,10 @@ public class Player {
                 exoPlayer.seekTo(offset);
             }
             exoPlayer.prepare(mediaSource);
-            exoPlayer.setPlayWhenReady(true);
+            exoPlayer.setPlayWhenReady(config.autoPlay());
+            if (!config.autoPlay()) {
+                paused = true;
+            }
             JSONObject payload = Payload.startEvent(exoPlayer, audioFocusString);
             new CallbackResponse(Player.this.callbackContext).send(PluginResult.Status.OK, payload, true);
         }


### PR DESCRIPTION
Adds the option for a user to not autoplay the exoplayer. By adding an attribute to the parameters of a boolean autoPlay.

The user than then control the player using the existing playPause method.